### PR TITLE
Images: add multi-arch support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,20 @@ certs:
 	openssl req -x509 -newkey rsa:4096 -nodes -keyout server/key.pem -out server/cert.pem -days 365 \
     -subj "/C=CH/ST=Berne/L=Berne/O=long-live-connection/OU=developers/CN=server"
 
-
 local-up: certs
 	docker-compose rm -f
 	docker-compose -f compose.yaml up --build
 
-build:
-	cd client && docker build -t dariomader/long-live-connection-client:v0.0.1 .
-	cd server && docker build -t dariomader/long-live-connection-server:v0.0.1 .
-  
+build-server:
+	cd server && docker buildx build -t dariomader/long-live-connection-server --platform linux/amd64,linux/arm64 .
+
+build-client: 
+	cd client && docker buildx build -t dariomader/long-live-connection-client --platform linux/amd64,linux/arm64 .
+
+release: release-server release-client
+
+release-server: build-server
+	cd server && docker buildx build -t dariomader/long-live-connection-server:v0.0.2 --platform linux/amd64,linux/arm64 --push .
+
+release-client: build-client
+	cd server && docker buildx build -t dariomader/long-live-connection-server:v0.0.2 --platform linux/amd64,linux/arm64 --push .

--- a/Readme.md
+++ b/Readme.md
@@ -44,9 +44,7 @@ To disable keep alives in the server, set ENV `SERVER_KEEP_ALIVE_ENABLED` to `fa
 
 ## Docker images
 
-Only arch64 images are available at the moment
-
 ```
-dariomader/long-live-connection-server:v0.0.1
-dariomader/long-live-connection-client:v0.0.1
+dariomader/long-live-connection-server:v0.0.2
+dariomader/long-live-connection-client:v0.0.2
 ```


### PR DESCRIPTION
This commit adds multi-arch support to the images.
`dariomader/long-live-connection-server:v0.0.2`
`dariomader/long-live-connection-client:v0.0.2`

Signed-off-by: darox <maderdario@gmail.com>