### PR TITLE
ENV: harmonize naming

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ This repo includes k8s manifests under the `install/kubernetes` directory. Use t
 
 ### Client
 
-- CLIENT_KEEP_ALIVE_SECONDS - The interval in seconds between keep alives. Default is `15` by the net/dialer package.
+- CLIENT_KEEP_ALIVE_INTERVAL_SECONDS - The interval in seconds between keep alives. Default is `15` by the net/dialer package.
 - CLIENT_KEEP_ALIVE_ENABLED - Enables keep alives in the client. If the server has keep alives enabled, the client will not send keep alives. Default is `true`
 - CLIENT_TLS_DISABLE_VERIFICATION - Disables TLS verification. Default is `true`
 - CLIENT_REQUEST_INTERVAL_SECONDS - The interval in seconds between requests. Default is `30` seconds

--- a/client/client.go
+++ b/client/client.go
@@ -25,7 +25,7 @@ func doRequest(client *http.Client, c clientConfig) (httpStatus, error) {
 
 func setupClient(c clientConfig) (http.Client, error) {
 	dialer := &net.Dialer{
-		KeepAlive: time.Duration(c.keepAliveSeconds) * time.Second,
+		KeepAlive: time.Duration(c.keepAliveIntervalSeconds) * time.Second,
 	}
 
 	// Create a custom http.Transport with the custom dialer
@@ -50,7 +50,7 @@ func setupClient(c clientConfig) (http.Client, error) {
 }
 
 func setupClientConfig() clientConfig {
-	viper.SetDefault("CLIENT_KEEP_ALIVE_SECONDS", 15) // 15 is the net dialer default
+	viper.SetDefault("CLIENT_KEEP_ALIVE_INTERVAL_SECONDS", 15) // 15 is the net dialer default
 	viper.SetDefault("CLIENT_KEEP_ALIVE_ENABLED", true)
 	viper.SetDefault("CLIENT_TLS_DISABLE_VERIFICATION", true)
 	viper.SetDefault("CLIENT_REQUEST_INTERVAL_SECONDS", 30)
@@ -59,20 +59,20 @@ func setupClientConfig() clientConfig {
 	viper.AutomaticEnv()
 
 	return clientConfig{
-		keepAliveSeconds:       viper.GetFloat64("CLIENT_KEEP_ALIVE_SECONDS"),
-		keepAliveEnabled:       viper.GetBool("CLIENT_KEEP_ALIVE_ENABLED"),
-		tlsDisableVerification: viper.GetBool("CLIENT_TLS_DISABLE_VERIFICATION"),
-		RequestIntervalSeconds: viper.GetFloat64("CLIENT_REQUEST_INTERVAL_SECONDS"),
-		serverURL:              viper.GetString("CLIENT_SERVER_URL"),
+		keepAliveIntervalSeconds: viper.GetFloat64("CLIENT_KEEP_ALIVE_INTERVAL_SECONDS"),
+		keepAliveEnabled:         viper.GetBool("CLIENT_KEEP_ALIVE_ENABLED"),
+		tlsDisableVerification:   viper.GetBool("CLIENT_TLS_DISABLE_VERIFICATION"),
+		RequestIntervalSeconds:   viper.GetFloat64("CLIENT_REQUEST_INTERVAL_SECONDS"),
+		serverURL:                viper.GetString("CLIENT_SERVER_URL"),
 	}
 }
 
 type clientConfig struct {
-	keepAliveSeconds       float64
-	keepAliveEnabled       bool
-	tlsDisableVerification bool
-	RequestIntervalSeconds float64
-	serverURL              string
+	keepAliveIntervalSeconds float64
+	keepAliveEnabled         bool
+	tlsDisableVerification   bool
+	RequestIntervalSeconds   float64
+	serverURL                string
 }
 
 type httpStatus string


### PR DESCRIPTION
Server keep alive interval was named differently
for client and for server. It's now the same
for both.

Signed-off-by: darox <maderdario@gmail.com>